### PR TITLE
Fix insertafter index to match current trellis wordpress-sites.conf

### DIFF
--- a/tasks/manage.yml
+++ b/tasks/manage.yml
@@ -14,7 +14,7 @@
 - name: Set Nginx Auth Type
   lineinfile:
     line: "  auth_basic 'Restricted';"
-    insertafter: index index.php;
+    insertafter: index index.php index.htm index.html;
     dest: "/etc/nginx/sites-available/{{ item.key }}.conf"
   with_dict: wordpress_sites
   when: item.value.htpasswd is defined


### PR DESCRIPTION
You get a nginx error without this change, because the index entry has changed in the new version of Trellis. What happens is it drops the Restricted entries outside the the server block and if you have more than one site you want to PW protect on the same server it throws an error on reload/restart. This keeps the entry inside the individual server blocks and you can run multiple PW protected sites.
