### PR TITLE
Support multiple user and update for the new trellis version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This role is specifically crafted to go with [Trellis](https://github.com/roots/
 Requirements
 ------------
 
-This role is made for Trellis (previously known as Bedrock-Ansible), so it depends on it. 
+This role is made for Trellis (previously known as Bedrock-Ansible), so it depends on it.
 
 Role Variables
 --------------
@@ -17,33 +17,22 @@ The role will read from the `wordpress_sites` dict set in environments files of 
 wordpress_sites:
   example.com:
     site_hosts:
-      - example.dev
+      - canonical: example.dev
     local_path: '../site' # path targeting local Bedrock site directory (relative to Ansible root)
-    repo: git@github.com:roots/bedrock.git
-    site_install: true
-    site_title: Example Site
-    admin_user: admin
-    admin_password: admin
-    admin_email: admin@example.dev    
+    local_path: ../site # path targeting local Bedrock site directory (relative to Ansible root)
+    admin_email: admin@example.dev
     multisite:
       enabled: false
-      subdomains: false
+    ssl:
+      enabled: false
+    cache:
+      enabled: false
     <b>htpasswd:
         name: user
         password: secret</b>
-    ssl:
-      enabled: false
-    system_cron: true
-    env:
-      wp_home: http://example.dev
-      wp_siteurl: http://example.dev/wp
-      wp_env: development
-      db_name: example_dev
-      db_user: example_dbuser
-      db_password: example_dbpassword
 </pre>
 
-You can also set the `htpasswd_path` to specify the folder used to store `htpasswd` files. The default is `/etc/htpasswd`. If you want to set this parameter, it is recommended that you set it in the `group_vars/all` file, so it will be the same for all environments.
+You can also set the `htpasswd_path` to specify the folder used to store `htpasswd` files. The default is `/etc/htpasswd`. If you want to set this parameter, it is recommended that you set it in the `group_vars/all/main.yml` file, so it will be the same for all environments.
 
 
 Dependencies
@@ -59,16 +48,17 @@ To get started, add this role (`louim.bedrock-site-protect`) to the `requirement
 ```
 - name: bedrock-site-protect
   src: louim.bedrock-site-protect
+  version: 1.1
 ```
 
 Then re-run the `ansible-galaxy install -r requirements.yml` to install the new role. You might need to add the `-f` option to force install of previously downloaded roles.
 
-You will also need to add the role to the `server.yml` like so: 
+You will also need to add the role to the `server.yml` like so:
 
 ```
 roles:
   ... other Trellis roles ...
-  - { role: bedrock-site-protect, tags: [wordpress, wordpress-setup] }
+  - { role: bedrock-site-protect, tags: [nginx, htpasswd] }
 ```
 
 
@@ -80,7 +70,8 @@ Adding / Removing Basic Authentication
 <pre>
   <b>htpasswd:
     name: user
-    password: secret</b></pre>
+    password: secret</b>
+</pre>
 
 in the `wordpress_sites` dict set, and reconfigure via: `ansible-playbook server.yml -e env=<environment>`.
 

--- a/README.md
+++ b/README.md
@@ -11,15 +11,16 @@ This role is made for Trellis (previously known as Bedrock-Ansible), so it depen
 Role Variables
 --------------
 
-The role will read from the `wordpress_sites` dict set in environments files of Trellis. It will search for the `htpasswd` key. Example:
+The role will read from the `wordpress_sites` dict set in environments files of Trellis. It will search for the `htpasswd` key.
 
+Example:
+--------
 <pre>
 wordpress_sites:
   example.com:
     site_hosts:
       - canonical: example.dev
     local_path: '../site' # path targeting local Bedrock site directory (relative to Ansible root)
-    local_path: ../site # path targeting local Bedrock site directory (relative to Ansible root)
     admin_email: admin@example.dev
     multisite:
       enabled: false
@@ -27,11 +28,11 @@ wordpress_sites:
       enabled: false
     cache:
       enabled: false
-    <b>htpasswd:
-        name: user
-        password: secret</b>
+    <b>htpasswd:</b>
+      <b>- name: user</b>
+        <b>password: secret</b>
 </pre>
-
+You may want to add the `htpasswd` block in the `vault.yml` file so password will be encrypted.
 You can also set the `htpasswd_path` to specify the folder used to store `htpasswd` files. The default is `/etc/htpasswd`. If you want to set this parameter, it is recommended that you set it in the `group_vars/all/main.yml` file, so it will be the same for all environments.
 
 
@@ -58,7 +59,7 @@ You will also need to add the role to the `server.yml` like so:
 ```
 roles:
   ... other Trellis roles ...
-  - { role: bedrock-site-protect, tags: [nginx, htpasswd] }
+  - { role: bedrock-site-protect, tags: [htpasswd] }
 ```
 
 

--- a/tasks/manage.yml
+++ b/tasks/manage.yml
@@ -1,14 +1,14 @@
 ---
 - name: Set htpasswd
   htpasswd:
-    path: "{{ htpasswd_path }}/{{ item.key }}"
+    path: "{{ htpasswd_path }}/{{ item.site_hosts.canonical }}"
     name: "{{ item.value.htpasswd.name }}"
     password: "{{ item.value.htpasswd.password }}"
     crypt_scheme: "{{ item.value.htpasswd.crypt|default(omit) }}"
     owner: root
     group: root
     mode: 0644
-  with_dict: wordpress_sites
+  with_dict: "{{ wordpress_sites }}"
   when: item.value.htpasswd is defined
 
 - name: Set Nginx Auth Type
@@ -16,7 +16,7 @@
     line: "  auth_basic 'Restricted';"
     insertafter: index index.php index.htm index.html;
     dest: "/etc/nginx/sites-available/{{ item.key }}.conf"
-  with_dict: wordpress_sites
+  with_dict: "{{ wordpress_sites }}"
   when: item.value.htpasswd is defined
   notify: reload nginx
 
@@ -25,7 +25,7 @@
     line: "  auth_basic_user_file {{ htpasswd_path }}/{{ item.key }};"
     insertafter: auth_basic 'Restricted';
     dest: "/etc/nginx/sites-available/{{ item.key }}.conf"
-  with_dict: wordpress_sites
+  with_dict: "{{ wordpress_sites }}"
   when: item.value.htpasswd is defined
   notify: reload nginx
 
@@ -34,7 +34,7 @@
     line: auth_basic "Restricted";
     state: absent
     dest: "/etc/nginx/sites-available/{{ item.key }}.conf"
-  with_dict: wordpress_sites
+  with_dict: "{{ wordpress_sites }}"
   when: item.value.htpasswd is not defined
   notify: reload nginx
 
@@ -43,6 +43,6 @@
     line: "auth_basic_user_file {{ htpasswd_path }}/{{ item.key }};"
     state: absent
     dest: "/etc/nginx/sites-available/{{ item.key }}.conf"
-  with_dict: wordpress_sites
+  with_dict: "{{ wordpress_sites }}"
   when: item.value.htpasswd is not defined
   notify: reload nginx

--- a/tasks/manage.yml
+++ b/tasks/manage.yml
@@ -1,15 +1,40 @@
 ---
+
+- name: Delete current htpasswd
+  file:
+    path: "{{ htpasswd_path }}/{{ item.value.site_hosts.0.canonical }}"
+    state: absent
+  with_dict: "{{ wordpress_sites }}"
+
 - name: Set htpasswd
   htpasswd:
-    path: "{{ htpasswd_path }}/{{ item.site_hosts.canonical }}"
-    name: "{{ item.value.htpasswd.name }}"
-    password: "{{ item.value.htpasswd.password }}"
-    crypt_scheme: "{{ item.value.htpasswd.crypt|default(omit) }}"
+    path: "{{ htpasswd_path }}/{{ item.0.site_hosts.0.canonical }}"
+    name: "{{ item.1.name }}"
+    password: "{{ item.1.password }}"
+    crypt_scheme: "{{ item.1.crypt|default(omit) }}"
     owner: root
     group: root
     mode: 0644
+  with_subelements:
+    - wordpress_sites
+    - htpasswd
+    - skip_missing: yes
+
+- name: Unset Nginx Auth Type
+  lineinfile:
+    regexp: "auth_basic 'Restricted';$"
+    state: absent
+    dest: "/etc/nginx/sites-available/{{ item.key }}.conf"
   with_dict: "{{ wordpress_sites }}"
-  when: item.value.htpasswd is defined
+  notify: reload nginx
+
+- name: Unset Nginx Auth file.
+  lineinfile:
+    regexp: "auth_basic_user_file {{ htpasswd_path }}/.*;"
+    state: absent
+    dest: "/etc/nginx/sites-available/{{ item.key }}.conf"
+  with_dict: "{{ wordpress_sites }}"
+  notify: reload nginx
 
 - name: Set Nginx Auth Type
   lineinfile:
@@ -22,27 +47,9 @@
 
 - name: Set Nginx Auth file.
   lineinfile:
-    line: "  auth_basic_user_file {{ htpasswd_path }}/{{ item.key }};"
+    line: "  auth_basic_user_file {{ htpasswd_path }}/{{ item.value.site_hosts.0.canonical }};"
     insertafter: auth_basic 'Restricted';
     dest: "/etc/nginx/sites-available/{{ item.key }}.conf"
   with_dict: "{{ wordpress_sites }}"
   when: item.value.htpasswd is defined
-  notify: reload nginx
-
-- name: Unset Nginx Auth Type
-  lineinfile:
-    line: auth_basic "Restricted";
-    state: absent
-    dest: "/etc/nginx/sites-available/{{ item.key }}.conf"
-  with_dict: "{{ wordpress_sites }}"
-  when: item.value.htpasswd is not defined
-  notify: reload nginx
-
-- name: Unset Nginx Auth file.
-  lineinfile:
-    line: "auth_basic_user_file {{ htpasswd_path }}/{{ item.key }};"
-    state: absent
-    dest: "/etc/nginx/sites-available/{{ item.key }}.conf"
-  with_dict: "{{ wordpress_sites }}"
-  when: item.value.htpasswd is not defined
   notify: reload nginx


### PR DESCRIPTION
You will need to create a the `tag 1.1` with the notice Breaking change.
You can now add multiple credentials.

Link to #5 
