### PR TITLE
Bedrock Site Protect needs to re-run after roles that modify Nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You will also need to add the role to the `server.yml` like so:
 ```
 roles:
   ... other Trellis roles ...
-  - { role: bedrock-site-protect, tags: [htpasswd] }
+  - { role: bedrock-site-protect, tags: [htpasswd, wordpress, wordpress-setup, letsencrypt] }
 ```
 
 


### PR DESCRIPTION
Running `ansible-playbook server.yml -e env=<environment> --tags <tag>` where tag is any of `[wordpress, wordpress-setup, letsencrypt]` will remove the Bedrock Site Protect Nginx configuration and disable the protection, independently of the settings in `wordpress_sites`.
That is a major pitfall because users do not expect Bedrock Site Protect do disappear if running `letsencrypt`, but it is the case.
Add these tags to make re-run Bedrock Site Protect when necessary to re-apply the modifications to Nginx `conf` files.